### PR TITLE
Styling for mobile devices

### DIFF
--- a/src/Homepage-map/styles.css
+++ b/src/Homepage-map/styles.css
@@ -390,6 +390,19 @@ text.button:hover {
   }
 }
 
+@media (max-width: 435px) {
+  .timeline {
+    display: flex;
+    margin-top: 0.5rem;
+    position: relative;
+    right: 1rem;
+  }
+  .slider-wrapper input {
+    width: 180px;
+    height: 40px;
+    z-index: 99;
+  }
+}
 /* 
   
   Reset button Media Queries 

--- a/src/components/Globe.js
+++ b/src/components/Globe.js
@@ -17,7 +17,7 @@ function Globe(props) {
     } else if (window.innerWidth < 780 && window.innerWidth >= 680) {
       fadeRate = 280;
     } else if (window.innerWidth < 680) {
-      fadeRate = 200;
+      fadeRate = 50;
     }
 
     window.addEventListener("scroll", function () {

--- a/src/components/GraphWidget.js
+++ b/src/components/GraphWidget.js
@@ -20,12 +20,20 @@ const styles = {
   textAlign: "center",
   textDecoration: "none",
 };
+const mobileStyles = {
+  fontFamily: "sans-serif",
+  textAlign: "center",
+  textDecoration: "none",
+  position: "relative",
+  right: "1rem",
+};
+const isMobile = window.innerWidth > 500;
 
 const CustomTooltip = ({ active, payload, label }) => {
   if (active && payload && payload.length) {
     return (
       <div>
-        <p>{` ${payload[0].value} `}</p>
+        <p>{` (${payload[0].payload.year}) - ${payload[0].value} `}</p>
       </div>
     );
   }
@@ -41,8 +49,12 @@ export const GraphWidget = ({ data, max }) => {
   const reduxYear = useSelector((state) => state.title_year);
   return (
     <div id="graphwidget">
-      <div style={styles}>
-        <ResponsiveContainer width={"100%"} height={200} zoom={0.8}>
+      <div style={isMobile ? styles : mobileStyles}>
+        <ResponsiveContainer
+          width={isMobile ? "100%" : "110%"}
+          height={200}
+          zoom={0.8}
+        >
           <BarChart
             width={600}
             height={300}
@@ -72,7 +84,7 @@ export const GraphWidget = ({ data, max }) => {
             <XAxis
               dataKey="year"
               type={"category"}
-              interval={4}
+              interval={window.innerWidth > 460 ? 4 : 5}
               minTickGap={5}
               tickLine={true}
               domain={["dataMin", "dataMax"]}

--- a/src/components/PollutantsContent.js
+++ b/src/components/PollutantsContent.js
@@ -77,7 +77,7 @@ function PollutantsContent() {
       numOfCards = 4;
     } else if (window.innerWidth >= 682) {
       numOfCards = 3;
-    } else if (window.innerWidth >= 400) {
+    } else if (window.innerWidth >= 421) {
       numOfCards = 2;
     } else {
       numOfCards = 1;
@@ -114,7 +114,7 @@ function PollutantsContent() {
       numOfCards = 4;
     } else if (window.innerWidth >= 682) {
       numOfCards = 3;
-    } else if (window.innerWidth >= 400) {
+    } else if (window.innerWidth >= 421) {
       numOfCards = 2;
     } else {
       numOfCards = 1;
@@ -150,7 +150,7 @@ function PollutantsContent() {
       numOfCards = 4;
     } else if (window.innerWidth >= 682) {
       numOfCards = 3;
-    } else if (window.innerWidth >= 400) {
+    } else if (window.innerWidth >= 421) {
       numOfCards = 2;
     } else {
       numOfCards = 1;
@@ -394,7 +394,7 @@ function PollutantsContent() {
                   : () => handleDisplayPanel("SO2", 4)
               }
             >
-              {descriptionActive && currentPollutant === "S02"
+              {descriptionActive && currentPollutant === "SO2"
                 ? "Close"
                 : "Learn More"}
             </button>

--- a/src/components/styles/AboutContent.css
+++ b/src/components/styles/AboutContent.css
@@ -62,3 +62,38 @@
     padding-top: 5rem;
   }
 }
+@media (max-width: 1300px) {
+  .description {
+    background-color: white;
+    border-radius: 1rem;
+    margin-bottom: 5rem;
+    padding-left: 3rem;
+    padding-right: 3rem;
+    padding-top: 3rem;
+    padding-bottom: 3rem;
+  }
+  .description p {
+    font-size: 1.2rem;
+    font-weight: lighter;
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+  }
+}
+
+@media (max-width: 1000px) {
+  .description {
+    background-color: white;
+    border-radius: 1rem;
+    margin-bottom: 5rem;
+    padding-left: 2rem;
+    padding-right: 2rem;
+    padding-top: 3rem;
+    padding-bottom: 3rem;
+  }
+  .description p {
+    font-size: 1rem;
+    font-weight: lighter;
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+  }
+}

--- a/src/components/styles/CustomHeader.css
+++ b/src/components/styles/CustomHeader.css
@@ -31,7 +31,7 @@
   }
 }
 
-@media (max-width: 1037px) {
+@media (max-width: 1054px) {
   .header-logo {
     display: none;
   }

--- a/src/components/styles/CustomNav.css
+++ b/src/components/styles/CustomNav.css
@@ -147,3 +147,27 @@
     padding-right: 1rem;
   }
 }
+
+@media (max-width: 450px) {
+  .mobile-logo {
+    display: block;
+    height: 2rem;
+    padding-right: 0.25rem;
+    padding-left: 0.25rem;
+    top: 1.4rem;
+  }
+  .navbar-logo {
+    width: 9rem;
+    height: auto;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    margin-left: 0rem;
+    margin-right: 0rem;
+  }
+  .navbar-logo {
+    width: 8rem;
+    height: auto;
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+}

--- a/src/components/styles/CustomNav.css
+++ b/src/components/styles/CustomNav.css
@@ -101,7 +101,7 @@
 }
 
 /* Navbar collapse at specific width */
-@media (max-width: 1037px) {
+@media (max-width: 1054px) {
   .toggle-button {
     display: flex;
   }

--- a/src/components/styles/Globe.css
+++ b/src/components/styles/Globe.css
@@ -140,3 +140,15 @@
     left: 0rem;
   }
 }
+@media (max-width: 650px) {
+  #graph_wrapper {
+    background-color: #f5f5f5;
+    border-bottom-right-radius: 1.5rem;
+    border-bottom-left-radius: 1.5rem;
+    padding: 1.5rem 1.5rem 1.5rem 1.5em;
+    width: 91%;
+    position: relative;
+    top: -57rem;
+    left: 0rem;
+  }
+}

--- a/src/components/styles/InteractiveMap.css
+++ b/src/components/styles/InteractiveMap.css
@@ -63,6 +63,18 @@
   }
 }
 
+@media (max-width: 650px) {
+  #interactive-map {
+    background-color: #f5f5f5;
+    border-radius: 3%;
+    padding: 1.5rem 1.5rem 1.5rem 1.5em;
+    width: 70%;
+    scale: 1.3;
+    position: relative;
+    top: -65rem;
+  }
+}
+
 /* @media (800px <= width <= 1000px) {
   .USMap {
     right: 1rem;

--- a/src/components/styles/PollutantsContent.css
+++ b/src/components/styles/PollutantsContent.css
@@ -126,3 +126,20 @@ td {
   overflow: hidden;
   width: 120%;
 }
+
+@media (max-width: 453px) {
+  .cards {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    margin-left: 0rem;
+  }
+  .panel {
+    padding: 1.5rem;
+    display: none;
+    background-color: white;
+    border-radius: 20px;
+    overflow: hidden;
+    width: 120%;
+  }
+}


### PR DESCRIPTION
This PR consists of mostly styling changes to the homepage, as well as some styling to the about page and pollutants page, to make them look presentable on mobile devices.  This PR stretches the graph in a mobile view, and reduces the number of labels along the x-axis.  It also shrinks the time slider, as well as spaces out the images in the navbar.